### PR TITLE
Support wwwauth[] which added in Git 2.41.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,10 +57,11 @@ func printCredential(token string) {
 }
 
 type credentialInput struct {
-	host     string
-	protocol string
-	username string
-	password string
+	host           string
+	protocol       string
+	username       string
+	password       string
+	wwwauthHeaders []string
 }
 
 func (c *credentialInput) ReadFrom(r io.Reader) (int64, error) {
@@ -80,6 +81,8 @@ func (c *credentialInput) ReadFrom(r io.Reader) (int64, error) {
 			c.username = kv[1]
 		case "password":
 			c.password = kv[1]
+		case "wwwauth[]":
+			c.wwwauthHeaders = append(c.wwwauthHeaders, kv[1])
 		default:
 			return 0, fmt.Errorf("input text is invalid: input line=%s", text)
 		}


### PR DESCRIPTION
Hi.

Since Git 2.41, git-credential-github-apps doesn't work properly.
This is because `wwwauth[]` was added to the credential helper protocol.

This pull request adds support for `wwwauth[]`. It's working correctly in my environment.

Thank you for the great software.

* https://github.blog/2023-06-01-highlights-from-git-2-41/
* https://github.com/git/git/compare/af5388d2ddb0bc7c22fbe698078f4ca07879d954...5f2117b24f568ecc789c677748d70ccd538b16ba
* https://git-scm.com/docs/git-credential#Documentation/git-credential.txt-codewwwauthcode